### PR TITLE
Added option for complex env mappings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 sudo: false
 go:
-  - 1.16.x
+  - 1.19.x
 services:
   - docker
 install:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TAG := $(shell git rev-parse --short HEAD)
 DIR := $(shell pwd -L)
 
-SDCLI_VERSION:=v1.2.0
+SDCLI_VERSION:=v3.0.0
 SDCLI:=docker run -ti --mount src="$(DIR)",target="$(DIR)",type="bind" -w "$(DIR)" \
 	asecurityteam/sdcli:$(SDCLI_VERSION)
 

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	_ "embed"
+	"flag"
 	"fmt"
 	"os"
 
@@ -12,7 +13,21 @@ import (
 var usage string
 
 func main() {
-	cmd, err := mapper.CommandWithEnvOverrides(os.Args[1:], os.Environ())
+	var envSep string
+	flag.StringVar(&envSep, "envSep", ":", "a string used to separate target from source for mapping. defaults to ':'")
+
+	var complexVar bool
+	flag.BoolVar(&complexVar, "complex", false, "a boolean to show what mode to interpret source variables in. "+
+		"true allows for combining multiple target variables but requires  '||VALUE||' as a delimiter. ex: "+
+		"TARGET:cat||SOURCE1||:||SOURCE2|| where SOURCE1 is foo and SOURCE2 is bar becomes 'catfoo:bar'. defaults to false")
+
+	flag.Parse()
+
+	conf := mapper.Config{
+		EnvSeparator: envSep,
+		ComplexVar:   complexVar,
+	}
+	cmd, err := mapper.CommandWithEnvOverrides(conf, os.Args[1:], os.Environ())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n\n%s", err.Error(), usage)
 		os.Exit(1)

--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -12,6 +12,11 @@ type envMapping struct {
 	From string
 }
 
+type Config struct {
+	EnvSeparator string
+	ComplexVar   bool
+}
+
 func parseMappings(src []string, sep string) ([]envMapping, error) {
 	mapping := make([]envMapping, 0, len(src))
 	targets := make(map[string]bool, len(src))
@@ -41,6 +46,27 @@ func resolveMappings(mappings []envMapping, resolver func(string) string) []stri
 	return resolved
 }
 
+// complexResolver will always attempt an os.GetEnv lookup for anything being substituted
+func complexResolver(unsubbed string) string {
+	delim := "||"
+	//Check that we have balanced delimiters before attempting
+	if strings.Count(unsubbed, delim)%2 == 0 {
+		subbed := unsubbed
+		for strings.Index(subbed, delim) >= 0 {
+			//Get whatever was before the substitution needed
+			pre, left, _ := strings.Cut(subbed, delim)
+			//Get the environment variable to sub and whatever was left
+			sub, after, _ := strings.Cut(left, delim)
+			lookup := os.Getenv(sub)
+
+			//This will sub in whatever the lookup got, and remove the placeholders thanks to cut
+			subbed = pre + lookup + after
+		}
+		return subbed
+	}
+	return unsubbed
+}
+
 func bisectSlice(src []string, sep string) ([]string, []string) {
 	for pos := range src {
 		if src[pos] == sep {
@@ -60,19 +86,26 @@ func bisectSlice(src []string, sep string) ([]string, []string) {
 // set to the value of SOURCE in input environment or empty string if the value is not set or is empty.
 //
 // For example, calling:
-// 		CommandWithEnvOverrides(
-//			[]string{"A:PATH","B:UNKNOWN_VARIABLE","--","/bin/sh"},
-//			[]string{"PATH=/bin"}
-//			)
+//
+//	CommandWithEnvOverrides(
+//		[]string{"A:PATH","B:UNKNOWN_VARIABLE","--","/bin/sh"},
+//		[]string{"PATH=/bin"}
+//		)
+//
 // Will result in exec.Cmd with path "/bin/sh" and with environment
-// 		{"A=/bin","B=", "PATH=/bin"}
+//
+//	{"A=/bin","B=", "PATH=/bin"}
+//
 // Where A is assigned to whatever value PATH is set to, and B is set to empty value as the UNKNOWN_VARIABLE is not
 // defined in inputEnv.
 //
 // Separator:
-//		"--"
+//
+//	"--"
+//
 // is used to divide "TARGET:SOURCE" mappings and the path to the command with (optional) arguments.
-func CommandWithEnvOverrides(inputArgs []string, inputEnv []string) (*exec.Cmd, error) {
+func CommandWithEnvOverrides(conf Config, inputArgs []string, inputEnv []string) (*exec.Cmd, error) {
+
 	mapNames, cmdLine := bisectSlice(inputArgs, "--")
 	if len(cmdLine) < 1 || len(cmdLine[0]) < 1 {
 		return nil, fmt.Errorf("missing command path")
@@ -80,11 +113,17 @@ func CommandWithEnvOverrides(inputArgs []string, inputEnv []string) (*exec.Cmd, 
 	cmdPath := cmdLine[0]
 	cmdArgs := cmdLine[1:]
 
-	mappings, err := parseMappings(mapNames, ":")
+	mappings, err := parseMappings(mapNames, conf.EnvSeparator)
 	if err != nil {
 		return nil, err
 	}
-	envOverrides := resolveMappings(mappings, os.Getenv)
+
+	resolver := os.Getenv
+	if conf.ComplexVar {
+		resolver = complexResolver
+	}
+
+	envOverrides := resolveMappings(mappings, resolver)
 	command := exec.Command(cmdPath, cmdArgs...)
 	command.Env = append(inputEnv, envOverrides...) //envOverrides take precedence
 	return command, nil

--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -12,6 +12,7 @@ type envMapping struct {
 	From string
 }
 
+// Config is used to configure the complex mapper via flags parsed in main.go
 type Config struct {
 	EnvSeparator string
 	ComplexVar   bool
@@ -52,7 +53,7 @@ func complexResolver(unsubbed string) string {
 	//Check that we have balanced delimiters before attempting
 	if strings.Count(unsubbed, delim)%2 == 0 {
 		subbed := unsubbed
-		for strings.Index(subbed, delim) >= 0 {
+		for strings.Contains(subbed, delim) {
 			//Get whatever was before the substitution needed
 			pre, left, _ := strings.Cut(subbed, delim)
 			//Get the environment variable to sub and whatever was left

--- a/pkg/mapper/mapper_test.go
+++ b/pkg/mapper/mapper_test.go
@@ -3,6 +3,7 @@ package mapper
 import (
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -166,6 +167,13 @@ func Test_resolveMappings(t *testing.T) {
 	}
 }
 
+func defaultConf() Config {
+	return Config{
+		EnvSeparator: ":",
+		ComplexVar:   false,
+	}
+}
+
 func TestNewCommandWithOverrides(t *testing.T) {
 	type args struct {
 		inputArgs []string
@@ -215,7 +223,7 @@ func TestNewCommandWithOverrides(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := CommandWithEnvOverrides(tt.args.inputArgs, tt.args.inputEnv)
+			got, err := CommandWithEnvOverrides(defaultConf(), tt.args.inputArgs, tt.args.inputEnv)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CommandWithEnvOverrides() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -232,6 +240,56 @@ func TestNewCommandWithOverrides(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got.Env, tt.wantEnv) {
 				t.Errorf("CommandWithEnvOverrides().Path got = %v, want %v", got.Env, tt.wantEnv)
+			}
+		})
+	}
+}
+
+// setEnvMap expects an array of vars in the form of "TARGET=SOURCE" and sets them with testing.SetEnv
+func setEnvMap(t *testing.T, envVars []string) error {
+	split, err := parseMappings(envVars, "=")
+	if err != nil {
+		return err
+	}
+	for _, mapping := range split {
+		t.Setenv(mapping.To, mapping.From)
+	}
+	return nil
+}
+
+func TestComplexResolver(t *testing.T) {
+	tests := []struct {
+		name     string
+		unsubbed string
+		envVars  []string
+		expected string
+	}{
+		{
+			"successful complex sub",
+			"cat,||SOURCE1||:||SOURCE2||",
+			[]string{"SOURCE1=foo", "SOURCE2=bar"},
+			"cat,foo:bar",
+		},
+		{
+			"unbalanced complex sub",
+			"cat,SOURCE1||:||SOURCE2||",
+			[]string{"SOURCE1=dog", "SOURCE2=fish"},
+			"cat,SOURCE1||:||SOURCE2||",
+		},
+		{
+			"unset sources",
+			"||SOURCE1||:||SOURCE2||",
+			[]string{"SOURCE1=ferret"},
+			"ferret:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setEnvMap(t, tt.envVars)
+			subbed := complexResolver(tt.unsubbed)
+			if strings.Compare(subbed, tt.expected) != 0 {
+				t.Errorf("Complex resolver test expected %s but got %s", tt.expected, subbed)
 			}
 		})
 	}

--- a/pkg/mapper/mapper_test.go
+++ b/pkg/mapper/mapper_test.go
@@ -286,7 +286,10 @@ func TestComplexResolver(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			setEnvMap(t, tt.envVars)
+			err := setEnvMap(t, tt.envVars)
+			if err != nil {
+				t.Error(err)
+			}
 			subbed := complexResolver(tt.unsubbed)
 			if strings.Compare(subbed, tt.expected) != 0 {
 				t.Errorf("Complex resolver test expected %s but got %s", tt.expected, subbed)


### PR DESCRIPTION
This is in support of allowing what I'm calling "complex" mapping for the env-mapper tool.

We need to map something of the form TARGET=${SOURCE1}:${SOURCE2}, the current mapper tool will not allow this since it tries to do an immediate os.GetEnv lookup on the right side of that expression

Please let me know if different delimiters or flag names (or a totally different solution) is desired. I had this idea towards the end of our cycle and wanted to get it out while it was still in mind.