### PR TITLE
Fix argument handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ func main() {
 		EnvSeparator: envSep,
 		ComplexVar:   complexVar,
 	}
-	cmd, err := mapper.CommandWithEnvOverrides(conf, os.Args[1:], os.Environ())
+	cmd, err := mapper.CommandWithEnvOverrides(conf, flag.Args(), os.Environ()) // flag.Args() gives positional arguments left after parsing defined flags
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n\n%s", err.Error(), usage)
 		os.Exit(1)


### PR DESCRIPTION
Use `flag.Args()` instead of `os.Args`, this way we pass only positional parameters to env override.
This avoids the previous incorrect behavior where the flags that were already parsed were in addition used as positional parameters.