### PR TITLE
Update pushed ARM image to `linux/arm64/v8`

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -58,7 +58,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64/v8
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.METAID.outputs.tags }}
           labels: ${{ steps.METAID.outputs.labels }}


### PR DESCRIPTION
Updates the pushed ARM image to be the one that is M1 Macbook compatible, `linux/arm64/v8`. Same as what is done in [sdcli](https://github.com/asecurityteam/sdcli/blob/master/.github/workflows/docker-image.yml#L61).